### PR TITLE
Pass in view controller instead of globally getting it

### DIFF
--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -68,7 +68,7 @@ IB_DESIGNABLE
 /**
  *  Presents the snackbar to the user for the configured duration of time.
  */
-- (void)show;
+- (void)show:(UIViewController *)inViewController;
 /**
  *  Removes the snackbar from the screen. Calls the snackbar's dismissal block if one exists, unless the snackbar has its isLongRunning property set to YES and it action button has already been pressed by the user. This message is shorthand for calling dismissAnimated with YES as the argument.
  */

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -105,8 +105,8 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     CGContextRestoreGState(ctx);
 }
 
-- (void)show {
-    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+- (void)show:(UIViewController *)inViewController {
+    UIViewController *topController = inViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -106,6 +106,10 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 }
 
 - (void)show:(UIViewController *)inViewController {
+    
+    // instead of using the keywindow.rootViewController, use a passed in view controller
+    // this is because keyWindow.rootViewController is nil when we have a whisper
+    // being presented
     UIViewController *topController = inViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;


### PR DESCRIPTION
@AndrewGable please review
## Details

Same problem that we saw with whispers --- modifying the `keyWindow` causes funky things to happen. So we need to present our the snackbar from the root view controller 
## Tests
- Display snackbar while a whisper is present and confirm app doesn't crash. 
